### PR TITLE
Fix some achievements

### DIFF
--- a/src/dlls/VRAchievementsAndStatsTracker.cpp
+++ b/src/dlls/VRAchievementsAndStatsTracker.cpp
@@ -159,7 +159,7 @@ void VRAchievementsAndStatsTracker::SmthKilledSmth(struct entvars_s* pKiller, st
 			UTIL_VRGiveAchievementAll(VRAchievement::QE_PRECISURGERY);
 			pHostPlayer->GetAchievementsAndStatsData().FriendlyKilled();
 		}
-		else
+		else if (!FClassnameIs(pKilled, "monster_scientist_dead"))
 		{
 			pHostPlayer->GetAchievementsAndStatsData().AnyKilled();
 		}

--- a/src/dlls/VRAchievementsAndStatsTracker.cpp
+++ b/src/dlls/VRAchievementsAndStatsTracker.cpp
@@ -54,7 +54,7 @@ void VRAchievementsAndStatsTracker::PlayerTakeNegativeCrushDamage(CBaseEntity* p
 
 void CheckRigorousResearchAchievement(CBasePlayer* pPlayer)
 {
-	if (pPlayer->GetAchievementsAndStatsData().m_exp1HeadcrabsKilled >= 5 && pPlayer->GetAchievementsAndStatsData().m_exp1HeadcrabsKilled >= 7)
+	if (pPlayer->GetAchievementsAndStatsData().m_exp1HeadcrabsKilled >= 5 && pPlayer->GetAchievementsAndStatsData().m_exp2HeadcrabsKilled >= 7)
 	{
 		UTIL_VRGiveAchievementAll(VRAchievement::QE_RIGOROUS);
 	}
@@ -126,8 +126,8 @@ void VRAchievementsAndStatsTracker::SmthKilledSmth(struct entvars_s* pKiller, st
 	{
 		// Power Up gargantua
 		if (FStrEq(STRING(INDEXENT(0)->v.model), "maps/c2a1.bsp")
-			&& FClassnameIs(pKiller, "trigger_hurt")
-			&& FStrEq(STRING(pKiller->targetname), "electro_hurt"))
+			&& FClassnameIs(pKiller, "env_laser")
+			&& FStrEq(STRING(pKiller->targetname), "gargbeams"))
 		{
 			UTIL_VRGiveAchievementAll(VRAchievement::PU_BBQ);
 			pHostPlayer->GetAchievementsAndStatsData().AnyKilled();

--- a/src/dlls/monsters.h
+++ b/src/dlls/monsters.h
@@ -178,7 +178,9 @@ public:
 		SetTouch(nullptr);
 		m_hThrower = m_vrDragger;	// set this here. once the player let's go we check in StickyGibTouch or BounceGibTouch if we hit an NPC
 
-		if (m_vrDragger && m_vrDragger->IsNetClient() && FStrEq(STRING(pev->model), "models/agibs.mdl"))
+		if (m_vrDragger
+			&& m_vrDragger->IsNetClient()
+			&& (FStrEq(STRING(pev->model), "models/agibs.mdl") || FStrEq(STRING(pev->model), "models/SD/agibs.mdl")))
 		{
 			UTIL_VRGiveAchievement(m_vrDragger, VRAchievement::GEN_ALIENGIB);
 		}

--- a/src/dlls/nihilanth.cpp
+++ b/src/dlls/nihilanth.cpp
@@ -838,20 +838,6 @@ void CNihilanth::NextActivity()
 					{
 						m_iTeleport++;
 						pev->sequence = LookupSequence("attack1");  // zap
-
-						// check if we went through all tele targets!
-						{
-							sprintf_s(szText, "%s%d", m_szTeleportTouch, m_iTeleport);
-							pTouch = UTIL_FindEntityByTargetname(nullptr, szText);
-
-							sprintf_s(szText, "%s%d", m_szTeleportUse, m_iTeleport);
-							pTrigger = UTIL_FindEntityByTargetname(nullptr, szText);
-
-							if (pTrigger == nullptr || pTouch == nullptr)
-							{
-								UTIL_VRGiveAchievementAll(VRAchievement::N_EXPLORER);
-							}
-						}
 					}
 				}
 			}

--- a/src/dlls/triggers.cpp
+++ b/src/dlls/triggers.cpp
@@ -1267,6 +1267,15 @@ void CBaseTrigger::ActivateMultiTrigger(CBaseEntity* pActivator)
 					UTIL_VRGiveAchievement(pActivator, VRAchievement::BP_BROKENELVTR);
 				}
 			}
+			// nihilanth lair
+			else if (FStrEq(STRING(INDEXENT(0)->v.model), "maps/c4a3.bsp"))
+			{
+				// teleporter in last nihilanth space
+				if (FStrEq(STRING(pev->model), "*60"))
+				{
+					UTIL_VRGiveAchievement(pActivator, VRAchievement::N_EXPLORER);
+				}
+			}
 		}
 	}
 }
@@ -2049,15 +2058,6 @@ void CTriggerPush::Touch(CBaseEntity* pOther)
 								pPlayer->VRJustGotYeetedByBPTrain();
 							}
 						}
-						// residue processing map with all those conveyor belts
-						else if (FStrEq(STRING(INDEXENT(0)->v.model), "maps/c2a4c.bsp"))
-						{
-							// trigger_push that player has to pass when taking the wrong turn and coming back to start
-							if (FStrEq(STRING(pev->model), "*78"))
-							{
-								UTIL_VRGiveAchievement(pPlayer, VRAchievement::RP_MOEBIUS);
-							}
-						}
 					}
 				}
 			}
@@ -2074,6 +2074,20 @@ void CTriggerPush::Touch(CBaseEntity* pOther)
 
 			pevToucher->flags |= FL_BASEVELOCITY;
 			//			ALERT( at_console, "Vel %f, base %f\n", pevToucher->velocity.z, pevToucher->basevelocity.z );
+
+			if (pOther->IsNetClient())
+			{
+				CBasePlayer* pPlayer = dynamic_cast<CBasePlayer*>(pOther);
+
+				// player in residue processing map with all those conveyor belts interacts with
+				// trigger_push that player has to pass when taking the wrong turn and coming back to start
+				if (pPlayer
+					&& FStrEq(STRING(INDEXENT(0)->v.model), "maps/c2a4c.bsp")
+					&& FStrEq(STRING(pev->model), "*78"))
+				{
+					UTIL_VRGiveAchievement(pPlayer, VRAchievement::RP_MOEBIUS);
+				}
+			}
 		}
 	}
 }
@@ -2153,6 +2167,21 @@ void CBaseTrigger::TeleportTouch(CBaseEntity* pOther)
 		if (pPlayer)
 		{
 			pPlayer->VRJustTeleported(prevOrigin, prevAngles);
+
+			// endgame map
+			if (FStrEq(STRING(INDEXENT(0)->v.model), "maps/c5a1.bsp"))
+			{
+				// teleport at the exit of train to black screen (joined g-man)
+				if (FStrEq(STRING(pev->target), "endroom"))
+				{
+					UTIL_VRGiveAchievement(pPlayer, VRAchievement::END_LIMITLESS);
+				}
+				// teleport in the train to grunt army (refused g-man)
+				else if (FStrEq(STRING(pev->target), "loser"))
+				{
+					UTIL_VRGiveAchievement(pPlayer, VRAchievement::END_UNWINNABLE);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes following achievements:

- **Rigorous Research**
Kill all the aliens with all the experiments

Issue: typo in `if` condition, was checking twice for `m_exp1HeadcrabsKilled`, ignoring `m_exp2HeadcrabsKilled`
Tested locally, achivements is working, amount of killed headcraps tracked correctly (5 in first and 7 in second)

- **Smells Like BBQ**
Fry the Gargantua

Issue: Frying Gargantua with electricity had no effect on achievement.
Added logging on `pKiller->classname` and `pKiller->targetname` and found that values in code doesn't match to what's happenning in game.
Updated `classname` to `env_laser` and `targetname` to `gargbeams` and got achievement

- **Fascinating Specimen**
Pick up an alien gib

Issue: achievement was working only with HD models (`models/agibs.mdl`).
Added OR condition for SD models (`models/SD/agibs.mdl`) and got achievement locally

- **Möbius trip**
Repeat the conveyor loop

Issue: interacting with push trigger had no effect on achievement, because [it doesn't have](https://github.com/maxvollmer/Half-Life-VR/blob/main/src/dlls/triggers.cpp#L2031) `SF_TRIG_PUSH_ONCE` flag set.
For solution, I've moved entire achievement-related block with all `if` conditions inside `else` block of testing on `SF_TRIG_PUSH_ONCE` flag.
Again, tested locally and got achievement.

**Update, fixed more achievements:**

- **Explorer**
Get teleported to all of Nihilanth's spaces

On your advice on Discord, moved achivement logic from Nihilanth to ActivateMultiTrigger.
Achievement unlocks when player is teleported to last space with Gargantua

- **Limitless Potential**
Join the G-Man
- **Unwinnable Battle**
Don't join the G-Man

These achievements didn't had any code related to them.
Decompiled map and added logic to TeleportTouch:
If player in last map and gets teleported to end credits / last battle these achivements unlock.
Tested locally.

**Update part two:**

- **Pacifist**
Don't kill anything in the entire game (except Nihilanth and the Blast Pit tentacles ofc)

In Questionable Ethics upon entering the level with lobby, runaway saw machine was "killing" `monster_scientist_dead`. Added it as exception.